### PR TITLE
feat(ysb): 메인화면에 카테고리별 게임 리스트 전달

### DIFF
--- a/src/main/java/com/cnusw/balancetalk/BalanceTalkApplication.java
+++ b/src/main/java/com/cnusw/balancetalk/BalanceTalkApplication.java
@@ -11,4 +11,5 @@ public class BalanceTalkApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(BalanceTalkApplication.class, args);
 	}
+
 }

--- a/src/main/java/com/cnusw/balancetalk/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/comment/controller/CommentController.java
@@ -1,8 +1,8 @@
 package com.cnusw.balancetalk.domain.comment.controller;
 
-import com.cnusw.balancetalk.domain.comment.dto.response.CommentResponse;
+import com.cnusw.balancetalk.domain.comment.repository.dto.response.CommentResponse;
 import com.cnusw.balancetalk.domain.comment.service.CommentService;
-import com.cnusw.balancetalk.domain.comment.dto.request.CommentRequest;
+import com.cnusw.balancetalk.domain.comment.repository.dto.request.CommentRequest;
 import com.cnusw.balancetalk.domain.comment.entity.Comment;
 
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/cnusw/balancetalk/domain/comment/repository/dto/request/CommentRequest.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/comment/repository/dto/request/CommentRequest.java
@@ -1,4 +1,4 @@
-package com.cnusw.balancetalk.domain.comment.dto.request;
+package com.cnusw.balancetalk.domain.comment.repository.dto.request;
 
 import com.cnusw.balancetalk.domain.comment.entity.Comment;
 import com.cnusw.balancetalk.domain.game.entity.Game;

--- a/src/main/java/com/cnusw/balancetalk/domain/comment/repository/dto/response/CommentResponse.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/comment/repository/dto/response/CommentResponse.java
@@ -1,4 +1,4 @@
-package com.cnusw.balancetalk.domain.comment.dto.response;
+package com.cnusw.balancetalk.domain.comment.repository.dto.response;
 
 import com.cnusw.balancetalk.domain.comment.entity.Comment;
 

--- a/src/main/java/com/cnusw/balancetalk/domain/comment/service/CommentService.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/comment/service/CommentService.java
@@ -1,7 +1,7 @@
 package com.cnusw.balancetalk.domain.comment.service;
 
-import com.cnusw.balancetalk.domain.comment.dto.request.CommentRequest;
-import com.cnusw.balancetalk.domain.comment.dto.response.CommentResponse;
+import com.cnusw.balancetalk.domain.comment.repository.dto.request.CommentRequest;
+import com.cnusw.balancetalk.domain.comment.repository.dto.response.CommentResponse;
 import com.cnusw.balancetalk.domain.comment.entity.Comment;
 import com.cnusw.balancetalk.domain.comment.entity.CommentLikes;
 import com.cnusw.balancetalk.domain.comment.repository.CommentLikesRepository;

--- a/src/main/java/com/cnusw/balancetalk/domain/game/controller/GameRestController.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/game/controller/GameRestController.java
@@ -2,16 +2,14 @@ package com.cnusw.balancetalk.domain.game.controller;
 
 
 import com.cnusw.balancetalk.domain.game.controller.request.GameRequest;
+import com.cnusw.balancetalk.domain.game.controller.response.CategoryGamesResponse;
 import com.cnusw.balancetalk.domain.game.controller.response.GameResponse;
 import com.cnusw.balancetalk.domain.game.service.GameService;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,6 +21,12 @@ import java.util.List;
 public class GameRestController {
 
     private final GameService gameService;
+
+    @GetMapping("/")
+    @Operation(summary = "메인페이지", description = "여러 카테고리의 게임을 리스트로 보여준다")
+    public List<CategoryGamesResponse> getCategoryGames() {
+        return gameService.getCategoryGamesList();
+    }
 
     @PostMapping("/games/create")
     @Operation(summary = "게임 제작", description = "게임을 제작한다.")

--- a/src/main/java/com/cnusw/balancetalk/domain/game/controller/response/CategoryGamesResponse.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/game/controller/response/CategoryGamesResponse.java
@@ -1,0 +1,25 @@
+package com.cnusw.balancetalk.domain.game.controller.response;
+
+import com.cnusw.balancetalk.domain.game.entity.Game;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CategoryGamesResponse {
+    private String category;
+    private List<GameResponse> gamesInCategory;
+
+    public static CategoryGamesResponse from(List<GameResponse> gameResponses, String category) {
+        return CategoryGamesResponse.builder()
+                .gamesInCategory(gameResponses)
+                .category(category)
+                .build();
+    }
+}

--- a/src/main/java/com/cnusw/balancetalk/domain/game/controller/response/CategoryGamesResponse.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/game/controller/response/CategoryGamesResponse.java
@@ -1,6 +1,7 @@
 package com.cnusw.balancetalk.domain.game.controller.response;
 
 import com.cnusw.balancetalk.domain.game.entity.Game;
+import com.cnusw.balancetalk.domain.game.enums.Category;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,10 +14,10 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class CategoryGamesResponse {
-    private String category;
+    private Category category;
     private List<GameResponse> gamesInCategory;
 
-    public static CategoryGamesResponse from(List<GameResponse> gameResponses, String category) {
+    public static CategoryGamesResponse from(List<GameResponse> gameResponses, Category category) {
         return CategoryGamesResponse.builder()
                 .gamesInCategory(gameResponses)
                 .category(category)

--- a/src/main/java/com/cnusw/balancetalk/domain/game/controller/response/GameResponse.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/game/controller/response/GameResponse.java
@@ -1,8 +1,6 @@
 package com.cnusw.balancetalk.domain.game.controller.response;
 
 
-import java.util.List;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +17,8 @@ public class GameResponse {
     private String title;
     private long playerCount;
     private long likes;
+    private long optionId1;
+    private long optionId2;
     private String optionTitle1;
     private String optionTitle2;
     private String optionDescription1;
@@ -33,6 +33,8 @@ public class GameResponse {
                 .title(game.getTitle())
                 .playerCount(game.getPlayerCount())
                 .likes(game.getLikes())
+                .optionId1(option1.getId())
+                .optionId2(option2.getId())
                 .optionTitle1(option1.getTitle())
                 .optionTitle2(option2.getTitle())
                 .optionDescription1(option1.getDescription())

--- a/src/main/java/com/cnusw/balancetalk/domain/game/enums/Category.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/game/enums/Category.java
@@ -1,0 +1,15 @@
+package com.cnusw.balancetalk.domain.game.enums;
+
+public enum Category {
+
+    POPULARITY("좋아요순"),
+    VIEWS("조회수순"),
+    LATEST("최신순"),
+    GOLDENBALANCE("황금밸런스순");
+
+    private String name;
+
+    Category(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/cnusw/balancetalk/domain/game/repository/GameRepository.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/game/repository/GameRepository.java
@@ -3,6 +3,7 @@ package com.cnusw.balancetalk.domain.game.repository;
 import com.cnusw.balancetalk.domain.game.entity.Game;
 import jakarta.persistence.EntityManager;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,5 +12,6 @@ import java.util.Optional;
 @Repository
 public interface GameRepository extends JpaRepository<Game, Long> {
     public List<Game> findAllById(Long game_id);
+
     Game findGameById(Long id);
 }

--- a/src/main/java/com/cnusw/balancetalk/domain/game/service/GameService.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/game/service/GameService.java
@@ -4,6 +4,7 @@ import com.cnusw.balancetalk.domain.game.controller.request.GameRequest;
 import com.cnusw.balancetalk.domain.game.controller.response.CategoryGamesResponse;
 import com.cnusw.balancetalk.domain.game.controller.response.GameResponse;
 import com.cnusw.balancetalk.domain.game.entity.Game;
+import com.cnusw.balancetalk.domain.game.enums.Category;
 import com.cnusw.balancetalk.domain.game.repository.GameRepository;
 import com.cnusw.balancetalk.domain.member.entity.Member;
 import com.cnusw.balancetalk.domain.member.repository.MemberRepository;
@@ -134,28 +135,28 @@ public class GameService {
             if ((percentage <= 55) && (percentage >= 45) ) { goldenBalanceGameResponses.add(gameResponse); }
         }
 
-        return CategoryGamesResponse.from(goldenBalanceGameResponses, "goldenBalance");
+        return CategoryGamesResponse.from(goldenBalanceGameResponses, Category.GOLDENBALANCE);
     }
 
     // 인기순 카테고리
     // GameResponse 리스트와 카테고리를 CategoryGamesResponse Dto로 변환 후 반환
     private CategoryGamesResponse getCategoryGamesOfPopularity() {
         List<GameResponse> gameResponses = getGamesSortedByPopularity();
-        return CategoryGamesResponse.from(gameResponses, "popularity");
+        return CategoryGamesResponse.from(gameResponses, Category.POPULARITY);
     }
 
     // 조회수순 카테고리
     // GameResponse 리스트와 카테고리를 CategoryGamesResponse Dto로 변환 후 반환
     private CategoryGamesResponse getCategoryGamesOfViews() {
         List<GameResponse> gameResponses = getGamesSortedByViews();
-        return CategoryGamesResponse.from(gameResponses, "views");
+        return CategoryGamesResponse.from(gameResponses, Category.VIEWS);
     }
 
     // 최신순 카테고리
     // GameResponse 리스트와 카테고리를 CategoryGamesResponse Dto로 변환 후 반환
     private CategoryGamesResponse getCategoryGamesOfLatest() {
         List<GameResponse> gameResponses = getGamesSortedByViews();
-        return CategoryGamesResponse.from(gameResponses, "latest");
+        return CategoryGamesResponse.from(gameResponses, Category.LATEST);
     }
 
     // Game 엔티티를 GameResponse로 변환하여 리스트로 반환

--- a/src/main/java/com/cnusw/balancetalk/domain/game/service/GameService.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/game/service/GameService.java
@@ -131,7 +131,7 @@ public class GameService {
             int firstOptionVoteCount = voteRepository.findVotesByOption(option1.getId()).size();
             int secondOptionVoteCount = voteRepository.findVotesByOption(option2.getId()).size();
             double percentage = (firstOptionVoteCount / (firstOptionVoteCount+secondOptionVoteCount)) * 100.0;
-            if ((percentage <= 65) && (percentage >= 45) ) { goldenBalanceGameResponses.add(gameResponse); }
+            if ((percentage <= 55) && (percentage >= 45) ) { goldenBalanceGameResponses.add(gameResponse); }
         }
 
         return CategoryGamesResponse.from(goldenBalanceGameResponses, "goldenBalance");

--- a/src/main/java/com/cnusw/balancetalk/domain/game/service/GameService.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/game/service/GameService.java
@@ -128,9 +128,9 @@ public class GameService {
         for (GameResponse gameResponse : allGameResponses) {
             Option option1 = optionRepository.findOptionById(gameResponse.getOptionId1());
             Option option2 = optionRepository.findOptionById(gameResponse.getOptionId2());
-            int firstOptionLen = voteRepository.findVotesByOption(option1.getId()).size();
-            int secondOptionLen = voteRepository.findVotesByOption(option2.getId()).size();
-            double percentage = (firstOptionLen / (firstOptionLen+secondOptionLen)) * 100.0;
+            int firstOptionVoteCount = voteRepository.findVotesByOption(option1.getId()).size();
+            int secondOptionVoteCount = voteRepository.findVotesByOption(option2.getId()).size();
+            double percentage = (firstOptionVoteCount / (firstOptionVoteCount+secondOptionVoteCount)) * 100.0;
             if ((percentage <= 65) && (percentage >= 45) ) { goldenBalanceGameResponses.add(gameResponse); }
         }
 

--- a/src/main/java/com/cnusw/balancetalk/domain/game/service/GameService.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/game/service/GameService.java
@@ -128,8 +128,8 @@ public class GameService {
         for (GameResponse gameResponse : allGameResponses) {
             Option option1 = optionRepository.findOptionById(gameResponse.getOptionId1());
             Option option2 = optionRepository.findOptionById(gameResponse.getOptionId2());
-            int firstOptionLen = voteRepository.findVotesByOption(option1).size();
-            int secondOptionLen = voteRepository.findVotesByOption(option2).size();
+            int firstOptionLen = voteRepository.findVotesByOption(option1.getId()).size();
+            int secondOptionLen = voteRepository.findVotesByOption(option2.getId()).size();
             double percentage = (firstOptionLen / (firstOptionLen+secondOptionLen)) * 100.0;
             if ((percentage <= 65) && (percentage >= 45) ) { goldenBalanceGameResponses.add(gameResponse); }
         }

--- a/src/main/java/com/cnusw/balancetalk/domain/option/repository/OptionRepository.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/option/repository/OptionRepository.java
@@ -7,5 +7,6 @@ import org.springframework.stereotype.Repository;
 
 public interface OptionRepository extends JpaRepository<Option, Long> {
 
-    Option findByTitle(String title);
+    Option findOptionById(Long id);
+    Option findOptionByTitle(String title);
 }

--- a/src/main/java/com/cnusw/balancetalk/domain/vote/repository/VoteRepository.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/vote/repository/VoteRepository.java
@@ -1,10 +1,16 @@
 package com.cnusw.balancetalk.domain.vote.repository;
 
+import com.cnusw.balancetalk.domain.option.entity.Option;
 import com.cnusw.balancetalk.domain.vote.entity.Vote;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface VoteRepository extends JpaRepository<Vote, Long> {
 
+    @Query(value = "SELECT * FROM Vote b WHERE option_id = :option_id", nativeQuery = true)
+    List<Vote> findVotesByOption(Option option);
 }

--- a/src/main/java/com/cnusw/balancetalk/domain/vote/repository/VoteRepository.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/vote/repository/VoteRepository.java
@@ -12,5 +12,5 @@ import java.util.List;
 public interface VoteRepository extends JpaRepository<Vote, Long> {
 
     @Query(value = "SELECT * FROM Vote b WHERE option_id = :option_id", nativeQuery = true)
-    List<Vote> findVotesByOption(Option option);
+    List<Vote> findVotesByOption(Long option_id);
 }


### PR DESCRIPTION
카테고리별 게임리스트를 정리하기 위해 CategoryGameResponse Dto 생성.

GameService에서 인기순, 조회수순, 최신순, 황금밸런스 카테고리별로 CategoryGamesResponse를 만들어 이를 리스트로 묶은 후 GameRestController에서 반환