### PR TITLE
ADD Member Level & Experience and Credit Increasing Logic

### DIFF
--- a/src/main/java/com/cnusw/balancetalk/domain/game/entity/Game.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/game/entity/Game.java
@@ -55,6 +55,14 @@ public class Game extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    // Add a column for indicate whether it is gold-balance or not
+    /*
+    @Builder.Default
+    @Setter
+    @Getter
+    private boolean isGoldBalance = false;
+    */
+
     // Add a column for the number of reports
     @Builder.Default
     @Setter

--- a/src/main/java/com/cnusw/balancetalk/domain/game/service/GameService.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/game/service/GameService.java
@@ -1,8 +1,7 @@
 package com.cnusw.balancetalk.domain.game.service;
 
-import com.cnusw.balancetalk.domain.comment.entity.Comment;
-import com.cnusw.balancetalk.domain.comment.entity.CommentLikes;
-import com.cnusw.balancetalk.domain.comment.repository.CommentLikesRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.cnusw.balancetalk.domain.game.controller.request.GameRequest;
 import com.cnusw.balancetalk.domain.game.controller.response.CategoryGamesResponse;
 import com.cnusw.balancetalk.domain.game.controller.response.GameResponse;
@@ -13,6 +12,7 @@ import com.cnusw.balancetalk.domain.game.repository.GameLikesRepository;
 import com.cnusw.balancetalk.domain.game.repository.GameRepository;
 import com.cnusw.balancetalk.domain.member.entity.Member;
 import com.cnusw.balancetalk.domain.member.repository.MemberRepository;
+import com.cnusw.balancetalk.domain.member.service.MemberService;
 import com.cnusw.balancetalk.domain.option.entity.Option;
 import com.cnusw.balancetalk.domain.option.repository.OptionRepository;
 import com.cnusw.balancetalk.global.jwt.JwtUtil;
@@ -42,6 +42,9 @@ public class GameService {
     private final VoteRepository voteRepository;
     private final MemberRepository memberRepository;
     private final JwtUtil jwtUtil;
+
+    private final MemberService memberService;
+    private static final Logger log = LoggerFactory.getLogger(GameService.class);
 
     //게임 제작
     public Long createGame(GameRequest gameRequest, HttpServletRequest servletRequest) {
@@ -85,6 +88,14 @@ public class GameService {
         optionRepository.save(option1);
         optionRepository.save(option2);
 
+        // Increase 50 EXP for gameCreator
+        boolean levelUpdated = memberService.updateMemberLevel(member.getId(), 50);
+        if(levelUpdated) {
+            // If level increased, player can earn 100 credit
+            member.setCredit(member.getCredit() + 100);
+            log.info("Member {} leveled up to level {}", member.getId(), member.getLevel());
+            log.info("Member {} earned credit {}", member.getId(), 100);
+        }
         return game.getId();
     }
 

--- a/src/main/java/com/cnusw/balancetalk/domain/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/member/dto/response/MemberInfoResponse.java
@@ -17,6 +17,9 @@ public class MemberInfoResponse {
     private String nickname;
     private int age;
     private Region region;
+    private long level;
+    private long exp;
+    private long credit;
 
     public static MemberInfoResponse from(Member member) {
         return MemberInfoResponse.builder()
@@ -24,6 +27,9 @@ public class MemberInfoResponse {
                 .nickname(member.getNickname())
                 .age(member.getAge())
                 .region(member.getRegion())
+                .level(member.getLevel())
+                .exp(member.getExp())
+                .credit(member.getCredit())
                 .build();
     }
 }

--- a/src/main/java/com/cnusw/balancetalk/domain/member/entity/Member.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package com.cnusw.balancetalk.domain.member.entity;
 import java.util.ArrayList;
 import java.util.List;
 
+import lombok.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.cnusw.balancetalk.domain.comment.entity.CommentDislikes;
@@ -22,12 +23,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
-
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -54,6 +49,21 @@ public class Member extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private Region region;
+
+    @Builder.Default
+    @Setter
+    @Getter
+    private long level = 1;
+
+    @Builder.Default
+    @Setter
+    @Getter
+    private long exp = 0;
+
+    @Builder.Default
+    @Setter
+    @Getter
+    private long credit = 0;
 
     @Builder.Default
     @OneToMany(mappedBy = "member")

--- a/src/main/java/com/cnusw/balancetalk/domain/member/service/MemberService.java
+++ b/src/main/java/com/cnusw/balancetalk/domain/member/service/MemberService.java
@@ -31,6 +31,24 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
 
+    // Calculate & Update member's level
+    public boolean updateMemberLevel(long memberId, long addExp) {
+        Member member = memberRepository.findById(memberId).orElseThrow();
+        long currentLevel = member.getLevel();
+        long currentExp = addExp + member.getExp();
+
+        long requiredExpForLeverUp = (long) Math.pow(2, 4 + currentLevel);
+
+        if(currentExp < requiredExpForLeverUp) {
+            member.setExp(currentExp);
+            return false;
+        } else {
+            member.setLevel(currentLevel + 1);
+            member.setExp(currentExp - requiredExpForLeverUp);
+            return true;
+        }
+    }
+
     /**
      * 1. 요청 객체의 이메일을 통해 이미 존재하는 회원인지 검증한다.
      * 2. 존재하지 않는 회원이면 요청 객체로부터 Member 엔티티를 생성하여 저장한다.


### PR DESCRIPTION
멤버의 레벨 및 경험치, 크레딧 증가 로직을 추가하였습니다.
황금밸런스 관련 경험치 증가 및 크레딧 추가는 다음 부분에 대한 협의가 필요해 보입니다.
 - 황금밸런스 여부 판단 함수 추가
 - 황금밸런스 여부 판단의 최소 참여자 수